### PR TITLE
Add Chrome extension to hide specified YouTube channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # youtube-channel-filter
+
+This Chrome extension hides videos from specified YouTube channels. The filter
+works on search results, the home page, related videos, and anywhere else videos
+appear on youtube.com.
+
+## Usage
+
+1. Load the extension in Chrome via **More Tools > Extensions > Load unpacked**
+   and choose the `src` directory.
+2. Open the extension options to add channel IDs or names to block.
+3. Videos from those channels will be hidden whenever you browse YouTube.
+
+The list of blocked channels is stored using Chrome sync storage so it will be
+shared across your browsers where you are signed in (if sync is enabled).

--- a/src/content.js
+++ b/src/content.js
@@ -1,0 +1,58 @@
+const selectors = [
+  'ytd-video-renderer',
+  'ytd-grid-video-renderer',
+  'ytd-compact-video-renderer',
+  'ytd-rich-item-renderer',
+  'ytd-playlist-video-renderer',
+  'ytd-channel-renderer'
+];
+const selectorsString = selectors.join(',');
+let banned = [];
+
+function getIdentifier(link) {
+  if (!link) return null;
+  const idMatch = link.href.match(/\/channel\/([^/?]+)/);
+  if (idMatch) return idMatch[1].toLowerCase();
+  const nameMatch = link.href.match(/@([^/?]+)/);
+  if (nameMatch) return '@' + nameMatch[1].toLowerCase();
+  return null;
+}
+
+function hideIfBanned(node) {
+  const link = node.querySelector('a[href*="/channel/"], a[href*="/@"]');
+  const identifier = getIdentifier(link);
+  if (!identifier) return;
+  if (banned.some(b => identifier === b.toLowerCase())) {
+    node.style.display = 'none';
+  }
+}
+
+function filterExisting() {
+  document.querySelectorAll(selectorsString).forEach(hideIfBanned);
+}
+
+chrome.storage.sync.get({ banned: [] }, data => {
+  banned = data.banned;
+  filterExisting();
+});
+
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === 'sync' && changes.banned) {
+    banned = changes.banned.newValue;
+    filterExisting();
+  }
+});
+
+const observer = new MutationObserver(mutations => {
+  mutations.forEach(m => {
+    m.addedNodes.forEach(node => {
+      if (node.nodeType !== 1) return;
+      if (node.matches && node.matches(selectorsString)) {
+        hideIfBanned(node);
+      } else if (node.querySelectorAll) {
+        node.querySelectorAll(selectorsString).forEach(hideIfBanned);
+      }
+    });
+  });
+});
+observer.observe(document.documentElement, { childList: true, subtree: true });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,0 +1,16 @@
+{
+  "manifest_version": 3,
+  "name": "YouTube Channel Filter",
+  "description": "Hide videos from specified YouTube channels.",
+  "version": "1.0",
+  "permissions": ["storage"],
+  "host_permissions": ["*://*.youtube.com/*"],
+  "options_page": "options.html",
+  "content_scripts": [
+    {
+      "matches": ["*://*.youtube.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/src/options.html
+++ b/src/options.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>YouTube Channel Filter Options</title>
+</head>
+<body>
+  <h1>YouTube Channel Filter</h1>
+  <input id="newChannel" placeholder="Channel ID or name">
+  <button id="add">Add</button>
+  <ul id="list"></ul>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,36 @@
+const input = document.getElementById('newChannel');
+const list = document.getElementById('list');
+const addBtn = document.getElementById('add');
+
+function refresh() {
+  chrome.storage.sync.get({ banned: [] }, data => {
+    list.innerHTML = '';
+    data.banned.forEach(channel => {
+      const li = document.createElement('li');
+      li.textContent = channel;
+      const btn = document.createElement('button');
+      btn.textContent = 'Remove';
+      btn.addEventListener('click', () => {
+        chrome.storage.sync.set({ banned: data.banned.filter(c => c !== channel) }, refresh);
+      });
+      li.appendChild(btn);
+      list.appendChild(li);
+    });
+  });
+}
+
+addBtn.addEventListener('click', () => {
+  const channel = input.value.trim();
+  if (!channel) return;
+  chrome.storage.sync.get({ banned: [] }, data => {
+    if (!data.banned.includes(channel)) {
+      data.banned.push(channel);
+      chrome.storage.sync.set({ banned: data.banned }, refresh);
+    } else {
+      refresh();
+    }
+  });
+  input.value = '';
+});
+
+document.addEventListener('DOMContentLoaded', refresh);


### PR DESCRIPTION
## Summary
- implement `manifest.json` to register the extension
- add `content.js` that hides videos from blocked channels on YouTube
- provide an options page with `options.html` and `options.js` for managing the block list
- document usage in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684dc840bb5883308f484737ff1316e5