### PR TITLE
Add search shorts toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # youtube-channel-filter
+
+This Chrome extension hides videos from specified YouTube channels. The filter
+works on search results, the home page, related videos, Shorts (including the
+"Latest Shorts" shelf), and anywhere else videos appear on youtube.com.
+It can also hide all Shorts from search results if enabled in the options page.
+
+## Usage
+
+1. Load the extension in Chrome via **More Tools > Extensions > Load unpacked**
+   and choose the `src` directory.
+2. Open the extension options to add channel IDs or names to block.
+3. Optionally enable **Hide Shorts from search results** to remove Shorts
+   shelves when searching.
+4. Videos from those channels will be hidden whenever you browse YouTube.
+
+The list of blocked channels is stored using Chrome sync storage so it will be
+shared across your browsers where you are signed in (if sync is enabled).

--- a/src/content.js
+++ b/src/content.js
@@ -1,0 +1,84 @@
+const selectors = [
+  'ytd-video-renderer',
+  'ytd-grid-video-renderer',
+  'ytd-compact-video-renderer',
+  'ytd-rich-item-renderer',
+  'ytd-playlist-video-renderer',
+  'ytd-channel-renderer',
+  // Shorts elements
+  'ytd-reel-video-renderer',
+  'ytd-reel-item-renderer',
+  'ytd-reel-shelf-renderer',
+  'ytd-rich-shelf-renderer'
+];
+const selectorsString = selectors.join(',');
+let banned = [];
+let hideShortsSearch = false;
+
+function getIdentifier(link) {
+  if (!link) return null;
+  const idMatch = link.href.match(/\/channel\/([^/?]+)/);
+  if (idMatch) return idMatch[1].toLowerCase();
+  const nameMatch = link.href.match(/@([^/?]+)/);
+  if (nameMatch) return '@' + nameMatch[1].toLowerCase();
+  return null;
+}
+
+function hideIfBannedOrShort(node) {
+  const link = node.querySelector('a[href*="/channel/"], a[href*="/@"]');
+  const identifier = getIdentifier(link);
+  const bannedMatch = identifier && banned.some(b => identifier === b.toLowerCase());
+  const shortMatch =
+    hideShortsSearch &&
+    location.href.includes('/results') &&
+    (node.matches('ytd-reel-shelf-renderer, ytd-reel-video-renderer, ytd-reel-item-renderer') ||
+      node.querySelector('a[href*="/shorts/"]'));
+  if (bannedMatch || shortMatch) {
+    const shelf = node.closest('ytd-reel-shelf-renderer');
+    const target = shortMatch && shelf ? shelf : node;
+    target.style.display = 'none';
+  }
+}
+
+function filterExisting() {
+  document.querySelectorAll(selectorsString).forEach(hideIfBannedOrShort);
+}
+
+chrome.storage.sync.get({ banned: [], hideShortsSearch: false }, data => {
+  banned = data.banned;
+  hideShortsSearch = data.hideShortsSearch;
+  filterExisting();
+});
+
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === 'sync') {
+    if (changes.banned) {
+      banned = changes.banned.newValue;
+    }
+    if (changes.hideShortsSearch) {
+      hideShortsSearch = changes.hideShortsSearch.newValue;
+    }
+    filterExisting();
+  }
+});
+
+const observer = new MutationObserver(mutations => {
+  mutations.forEach(m => {
+    m.addedNodes.forEach(node => {
+      if (node.nodeType !== 1) return;
+      let target = null;
+      if (node.matches && node.matches(selectorsString)) {
+        target = node;
+      } else if (node.closest) {
+        target = node.closest(selectorsString);
+      }
+      if (target) {
+        hideIfBannedOrShort(target);
+      }
+      if (node.querySelectorAll) {
+        node.querySelectorAll(selectorsString).forEach(hideIfBannedOrShort);
+      }
+    });
+  });
+});
+observer.observe(document.documentElement, { childList: true, subtree: true });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,0 +1,16 @@
+{
+  "manifest_version": 3,
+  "name": "YouTube Channel Filter",
+  "description": "Hide videos from specified YouTube channels.",
+  "version": "1.0",
+  "permissions": ["storage"],
+  "host_permissions": ["*://*.youtube.com/*"],
+  "options_page": "options.html",
+  "content_scripts": [
+    {
+      "matches": ["*://*.youtube.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/src/options.html
+++ b/src/options.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>YouTube Channel Filter Options</title>
+</head>
+<body>
+  <h1>YouTube Channel Filter</h1>
+  <input id="newChannel" placeholder="Channel ID or name">
+  <button id="add">Add</button>
+  <ul id="list"></ul>
+  <label>
+    <input type="checkbox" id="hideShortsSearch"> Hide Shorts from search results
+  </label>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,42 @@
+const input = document.getElementById('newChannel');
+const list = document.getElementById('list');
+const addBtn = document.getElementById('add');
+const hideShortsCheckbox = document.getElementById('hideShortsSearch');
+
+function refresh() {
+  chrome.storage.sync.get({ banned: [], hideShortsSearch: false }, data => {
+    list.innerHTML = '';
+    data.banned.forEach(channel => {
+      const li = document.createElement('li');
+      li.textContent = channel;
+      const btn = document.createElement('button');
+      btn.textContent = 'Remove';
+      btn.addEventListener('click', () => {
+        chrome.storage.sync.set({ banned: data.banned.filter(c => c !== channel) }, refresh);
+      });
+      li.appendChild(btn);
+      list.appendChild(li);
+    });
+    hideShortsCheckbox.checked = data.hideShortsSearch;
+  });
+}
+
+addBtn.addEventListener('click', () => {
+  const channel = input.value.trim();
+  if (!channel) return;
+  chrome.storage.sync.get({ banned: [] }, data => {
+    if (!data.banned.includes(channel)) {
+      data.banned.push(channel);
+      chrome.storage.sync.set({ banned: data.banned }, refresh);
+    } else {
+      refresh();
+    }
+  });
+  input.value = '';
+});
+
+hideShortsCheckbox.addEventListener('change', () => {
+  chrome.storage.sync.set({ hideShortsSearch: hideShortsCheckbox.checked });
+});
+
+document.addEventListener('DOMContentLoaded', refresh);


### PR DESCRIPTION
## Summary
- document option for hiding Shorts from search results
- load and store `hideShortsSearch` setting in options and content scripts
- hide Shorts shelves and items in search when enabled

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684dc840bb5883308f484737ff1316e5